### PR TITLE
Handle receiving SIGTERM.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,7 @@ class Watcher(object):
    def __init__(self):
       self.child = os.fork()
       if self.child != 0: 
+         signal.signal(signal.SIGTERM, self.sig_term)
          self.watch()
 
    def watch(self):
@@ -26,6 +27,10 @@ class Watcher(object):
    def kill(self):
       try: os.kill(self.child, signal.SIGKILL)
       except OSError: pass
+
+   def sig_term(self, signum, frame):
+      self.kill()
+      sys.exit()
 
 def run_phenny(config): 
    if hasattr(config, 'delay'): 


### PR DESCRIPTION
Make phenny kill its child threads then exit when it receives a SIGTERM signal.

I needed to be able to have start-stop-daemon be able to kill phenny using a pidfile in order to write an initscript for my server. This will allow services to send SIGTERM signals to the parent phenny thread and phenny will take care of ending itself.
