### PR TITLE
.seen throws exception in IRC, when used without an argument

### DIFF
--- a/modules/seen.py
+++ b/modules/seen.py
@@ -14,7 +14,10 @@ from tools import deprecated
 def f_seen(self, origin, match, args): 
    """.seen <nick> - Reports when <nick> was last seen."""
    if origin.sender == '#talis': return
-   nick = match.group(2).lower()
+   nick = match.group(2)
+   if not nick:
+      return self.msg(origin.sender, 'Perhaps you meant ".seen username"')
+   nick = nick.lower()
    if not hasattr(self, 'seen'): 
       return self.msg(origin.sender, '?')
    if self.seen.has_key(nick): 


### PR DESCRIPTION
Added a simple condition to catch an not arguments sent to the f_seen function stopping exceptions in IRC with a friendly message.
