### PR TITLE
Supervisord needs a pid file for the process it needs to kill

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,10 +12,10 @@ import bot
 
 class Watcher(object):
    # Cf. http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/496735
-   def __init__(self):
+   def __init__(self, config_name='default'):
       self.child = os.fork()
       if self.child != 0:
-         f = open('/tmp/phenny.pid', 'w')
+         f = open('/tmp/phenny.%s.pid' % config_name, 'w')
          try:
              f.write(str(self.child))
          finally:
@@ -41,8 +41,9 @@ def run_phenny(config):
       p = bot.Phenny(config)
       p.run(config.host, config.port)
 
-   try: Watcher()
-   except Exception, e: 
+   config_name = os.path.basename(config.filename).split('.')[0]
+   try: Watcher(config_name)
+   except Exception, e:
       print >> sys.stderr, 'Warning:', e, '(in __init__.py)'
 
    while True: 

--- a/__init__.py
+++ b/__init__.py
@@ -10,11 +10,16 @@ http://inamidst.com/phenny/
 import sys, os, time, threading, signal
 import bot
 
-class Watcher(object): 
+class Watcher(object):
    # Cf. http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/496735
    def __init__(self):
       self.child = os.fork()
-      if self.child != 0: 
+      if self.child != 0:
+         f = open('/tmp/phenny.pid', 'w')
+         try:
+             f.write(str(self.child))
+         finally:
+             f.close()
          self.watch()
 
    def watch(self):

--- a/__init__.py
+++ b/__init__.py
@@ -12,10 +12,12 @@ import bot
 
 class Watcher(object):
    # Cf. http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/496735
-   def __init__(self, config_name='default'):
+   def __init__(self, config_file):
+      config_dir = os.path.dirname(config_file)
+      config_name = os.path.basename(config_file).split('.')[0]
       self.child = os.fork()
       if self.child != 0:
-         f = open('/tmp/phenny.%s.pid' % config_name, 'w')
+         f = open('%s/phenny.%s.pid' % (config_dir, config_name), 'w')
          try:
              f.write(str(self.child))
          finally:
@@ -41,8 +43,7 @@ def run_phenny(config):
       p = bot.Phenny(config)
       p.run(config.host, config.port)
 
-   config_name = os.path.basename(config.filename).split('.')[0]
-   try: Watcher(config_name)
+   try: Watcher(config.filename)
    except Exception, e:
       print >> sys.stderr, 'Warning:', e, '(in __init__.py)'
 


### PR DESCRIPTION
Supervisor can't kill processes that fork and handle signals in the child - it needs to be told about the child's PID by means of a pid file.
This commit allows running phenny under supervisor.

See http://supervisord.org/subprocess.html#pidproxy-program for specific documentation.
