### PR TITLE
Shebang fix

### DIFF
--- a/project
+++ b/project
@@ -1,3 +1,4 @@
+#!/bin/sh
 # project
 # Copyright 2008, Sean B. Palmer, inamidst.com
 # Licensed under the Eiffel Forum License 2.

--- a/project
+++ b/project
@@ -1,4 +1,3 @@
-#!/bin/bash
 # project
 # Copyright 2008, Sean B. Palmer, inamidst.com
 # Licensed under the Eiffel Forum License 2.


### PR DESCRIPTION
doesn't look like you're doing anything bash specific, and bash doesn't reside in /bin on the BSDs, so for portability's sake, bumped it down to /bin/sh so it'll be happy with any reasonably compliant POSIX sh derivative.
